### PR TITLE
Use interface{} for Other Types

### DIFF
--- a/begin.go
+++ b/begin.go
@@ -2,11 +2,13 @@ package slice_chain
 
 import (
 	"github.com/halprin/slice-chain/generator"
+	"github.com/halprin/slice-chain/helper"
 	"github.com/halprin/slice-chain/intermediate"
 )
 
-func FromSlice(theSlice []int) *intermediate.Link {
-	sliceGenerator := generator.FromSlice(theSlice)
+func FromSlice(slice interface{}) *intermediate.Link {
+	interfaceSlice := helper.InterfaceSlice(slice)
+	sliceGenerator := generator.FromSlice(interfaceSlice)
 
 	link := intermediate.NewLink(sliceGenerator)
 	return link

--- a/begin_test.go
+++ b/begin_test.go
@@ -1,0 +1,22 @@
+package slice_chain
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFunStuff(t *testing.T) {
+	stringSlice := []string{"DogCows", "goes", "Moof!", "Do", "you", "like", "Clarus", "the", "DogCow?"}
+	chain := FromSlice(stringSlice)
+
+	outputSlice := chain.Filter(func(value interface{}) bool {
+		stringValue, ok := value.(string)
+		if !ok {
+			return false
+		}
+
+		return len(stringValue) % 2 == 0
+	}).Skip(1).Slice()
+
+	fmt.Println(outputSlice)
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -4,15 +4,15 @@ import "errors"
 
 var Exhausted = errors.New("generator exhausted")
 
-func FromSlice(theSlice []int) func() (int, error) {
+func FromSlice(slice []interface{}) func() (interface{}, error) {
 	currentIndex := 0
 
-	return func() (int, error) {
-		if currentIndex >= len(theSlice) {
+	return func() (interface{}, error) {
+		if currentIndex >= len(slice) {
 			return 0, Exhausted
 		}
 
-		value := theSlice[currentIndex]
+		value := slice[currentIndex]
 		currentIndex++
 
 		return value, nil

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -8,7 +8,7 @@ import (
 func TestFromSliceWithLastTimeError(t *testing.T) {
 	assert := assert.New(t)
 
-	generator := FromSlice([]int{9})
+	generator := FromSlice([]interface{}{9})
 
 	_, err := generator()
 
@@ -25,7 +25,7 @@ func TestFromSliceWithCorrectOrder(t *testing.T) {
 	expectedFirstItem := 1
 	expectedSecondItem := 26
 	expectedThirdItem := 9
-	theSlice := []int{expectedFirstItem, expectedSecondItem, expectedThirdItem}
+	theSlice := []interface{}{expectedFirstItem, expectedSecondItem, expectedThirdItem}
 	generator := FromSlice(theSlice)
 
 	actualFirstItem, err := generator()
@@ -42,7 +42,7 @@ func TestFromSliceWithCorrectOrder(t *testing.T) {
 }
 
 func TestFromSliceEmpty(t *testing.T) {
-	generator := FromSlice([]int{})
+	generator := FromSlice([]interface{}{})
 
 	_, err := generator()
 

--- a/helper/interface.go
+++ b/helper/interface.go
@@ -1,0 +1,22 @@
+package helper
+
+import "reflect"
+
+func InterfaceSlice(slice interface{}) []interface{} {
+	concreteValue := reflect.ValueOf(slice)
+	if concreteValue.Kind() != reflect.Slice {
+		panic("non-slice type provided")
+	}
+
+	if concreteValue.IsNil() {
+		return nil
+	}
+
+	interfaceSlice := make([]interface{}, concreteValue.Len())
+
+	for currentIndex := 0; currentIndex < concreteValue.Len(); currentIndex++ {
+		interfaceSlice[currentIndex] = concreteValue.Index(currentIndex).Interface()
+	}
+
+	return interfaceSlice
+}

--- a/helper/interface_test.go
+++ b/helper/interface_test.go
@@ -1,0 +1,27 @@
+package helper
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestInterfaceSliceConversion(t *testing.T) {
+	inputSlice := []string{"DogCow", "Moof", "Clarus"}
+	actualSlice := InterfaceSlice(inputSlice)
+
+	assert.ElementsMatch(t, inputSlice, actualSlice)
+}
+
+func TestInterfaceSlicePanicsForNonSlice(t *testing.T) {
+	assert.Panics(t, func() {
+		InterfaceSlice(3)
+	})
+}
+
+func TestInterfaceSliceReturnsNil(t *testing.T) {
+	var inputSlice []int
+
+	actualSlice := InterfaceSlice(inputSlice)
+
+	assert.Nil(t, actualSlice)
+}

--- a/intermediate/link.go
+++ b/intermediate/link.go
@@ -3,10 +3,10 @@ package intermediate
 import "github.com/halprin/slice-chain/generator"
 
 type Link struct {
-	generator func() (int, error)
+	generator func() (interface{}, error)
 }
 
-func NewLink(generator func() (int, error)) *Link {
+func NewLink(generator func() (interface{}, error)) *Link {
 	return &Link{
 		generator: generator,
 	}
@@ -14,8 +14,8 @@ func NewLink(generator func() (int, error)) *Link {
 
 //chain methods
 
-func (receiver *Link) Filter(filterFunction func(int) bool) *Link {
-	filterGenerator := func() (int, error) {
+func (receiver *Link) Filter(filterFunction func(interface{}) bool) *Link {
+	filterGenerator := func() (interface{}, error) {
 		//go through the generator until you find an item that stays
 		for {
 			valueToFilter, err := receiver.generator()
@@ -43,7 +43,7 @@ func (receiver *Link) Skip(skipNumber int) *Link {
 func (receiver *Link) Limit(keepSize int) *Link {
 	itemsSeen := 0
 
-	limitGenerator := func() (int, error) {
+	limitGenerator := func() (interface{}, error) {
 		if itemsSeen >= keepSize {
 			return 0, generator.Exhausted
 		}
@@ -63,8 +63,8 @@ func (receiver *Link) Limit(keepSize int) *Link {
 
 //termination methods
 
-func (receiver *Link) Slice() []int {
-	endSlice := []int{}
+func (receiver *Link) Slice() []interface{} {
+	endSlice := []interface{}{}
 
 	for {
 		currentValue, err := receiver.generator()
@@ -76,7 +76,7 @@ func (receiver *Link) Slice() []int {
 	}
 }
 
-func (receiver *Link) ForEach(forEachFunction func(int)) {
+func (receiver *Link) ForEach(forEachFunction func(interface{})) {
 	for {
 		currentValue, err := receiver.generator()
 		if err != nil {
@@ -99,7 +99,7 @@ func (receiver *Link) Count() int {
 	}
 }
 
-func (receiver *Link) First() *int {
+func (receiver *Link) First() *interface{} {
 	value, err := receiver.generator()
 	if err != nil {
 		return nil
@@ -108,8 +108,8 @@ func (receiver *Link) First() *int {
 	return &value
 }
 
-func (receiver *Link) Last() *int {
-	var last *int
+func (receiver *Link) Last() *interface{} {
+	var last *interface{}
 
 	for {
 		currentValue, err := receiver.generator()
@@ -121,7 +121,7 @@ func (receiver *Link) Last() *int {
 	}
 }
 
-func (receiver *Link) AllMatch(allMatchFunction func(int) bool) bool {
+func (receiver *Link) AllMatch(allMatchFunction func(interface{}) bool) bool {
 	for {
 		currentValue, err := receiver.generator()
 		if err != nil {
@@ -134,7 +134,7 @@ func (receiver *Link) AllMatch(allMatchFunction func(int) bool) bool {
 	}
 }
 
-func (receiver *Link) AnyMatch(anyMatchFunction func(int) bool) bool {
+func (receiver *Link) AnyMatch(anyMatchFunction func(interface{}) bool) bool {
 	for {
 		currentValue, err := receiver.generator()
 		if err != nil {
@@ -147,6 +147,6 @@ func (receiver *Link) AnyMatch(anyMatchFunction func(int) bool) bool {
 	}
 }
 
-func (receiver *Link) NoneMatch(noneMatchFunction func(int) bool) bool {
+func (receiver *Link) NoneMatch(noneMatchFunction func(interface{}) bool) bool {
 	return !receiver.AnyMatch(noneMatchFunction)
 }

--- a/intermediate/link_chain_test.go
+++ b/intermediate/link_chain_test.go
@@ -2,18 +2,20 @@ package intermediate
 
 import (
 	"github.com/halprin/slice-chain/generator"
+	"github.com/halprin/slice-chain/helper"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestFilter(t *testing.T) {
 	inputSlice    := []int{7, 4, 2, 3, 9, 5, 6, 0, 8, 1}
-	expectedSlice := []int{7, 9, 6, 8}
-	generation := generator.FromSlice(inputSlice)
+	expectedSlice := helper.InterfaceSlice([]int{7, 9, 6, 8})
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
-	filterFunction := func(value int) bool {
-		return value > 5
+	filterFunction := func(value interface{}) bool {
+		intValue := value.(int)
+		return intValue > 5
 	}
 
 	actualSlice := link.Filter(filterFunction).Slice()
@@ -23,42 +25,42 @@ func TestFilter(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	inputSlice    := []int{7, 4, 2, 3, 9, 5, 6, 0, 8, 1}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
 	howManyToSkip := 3
 	actualSlice := link.Skip(howManyToSkip).Slice()
 
-	assert.Equal(t, inputSlice[howManyToSkip:], actualSlice)
+	assert.Equal(t, helper.InterfaceSlice(inputSlice[howManyToSkip:]), actualSlice)
 }
 
 func TestSkipLargerThanSlice(t *testing.T) {
 	inputSlice    := []int{7, 4, 2, 3, 9, 5, 6, 0, 8, 1}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
 	actualSlice := link.Skip(len(inputSlice) + 1).Slice()
 
-	assert.Equal(t, []int{}, actualSlice)
+	assert.Equal(t, []interface{}{}, actualSlice)
 }
 
 func TestLimit(t *testing.T) {
 	inputSlice    := []int{7, 4, 2, 3, 9, 5, 6, 0, 8, 1}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
 	howManyToKeep := 6
 	actualSlice := link.Limit(howManyToKeep).Slice()
 
-	assert.Equal(t, inputSlice[:howManyToKeep], actualSlice)
+	assert.Equal(t, helper.InterfaceSlice(inputSlice[:howManyToKeep]), actualSlice)
 }
 
 func TestLimitLargerThanSlice(t *testing.T) {
 	inputSlice    := []int{7, 4, 2, 3, 9, 5, 6, 0, 8, 1}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
 	actualSlice := link.Limit(len(inputSlice) + 1).Slice()
 
-	assert.Equal(t, inputSlice, actualSlice)
+	assert.Equal(t, helper.InterfaceSlice(inputSlice), actualSlice)
 }

--- a/intermediate/link_termination_test.go
+++ b/intermediate/link_termination_test.go
@@ -3,27 +3,28 @@ package intermediate
 
 import (
 	"github.com/halprin/slice-chain/generator"
+	"github.com/halprin/slice-chain/helper"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestSlice(t *testing.T) {
 	expectedSlice := []int{987, 8, 26}
-	generation := generator.FromSlice(expectedSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(expectedSlice))
 	link := NewLink(generation)
 
 	actualSlice := link.Slice()
 
-	assert.Equal(t, expectedSlice, actualSlice)
+	assert.Equal(t, helper.InterfaceSlice(expectedSlice), actualSlice)
 }
 
 func TestForEach(t *testing.T) {
 	inputSlice := []int{987, 8, 26}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
-	var seenItems []int
-	forEachFunction := func(value int) {
+	var seenItems []interface{}
+	forEachFunction := func(value interface{}) {
 		seenItems = append(seenItems, value)
 	}
 	link.ForEach(forEachFunction)
@@ -33,7 +34,7 @@ func TestForEach(t *testing.T) {
 
 func TestCount(t *testing.T) {
 	inputSlice := []int{987, 8, 26}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
 	actualCount := link.Count()
@@ -45,7 +46,7 @@ func TestFirst(t *testing.T) {
 	assert := assert.New(t)
 
 	inputSlice := []int{987, 8, 26}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
 	actualFirst := link.First()
@@ -56,7 +57,7 @@ func TestFirst(t *testing.T) {
 
 func TestFirstWithEmptySlice(t *testing.T) {
 	var inputSlice []int
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
 	actualFirst := link.First()
@@ -68,7 +69,7 @@ func TestLast(t *testing.T) {
 	assert := assert.New(t)
 
 	inputSlice := []int{987, 8, 26}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
 	actualLast := link.Last()
@@ -79,7 +80,7 @@ func TestLast(t *testing.T) {
 
 func TestLastWithEmptySlice(t *testing.T) {
 	var inputSlice []int
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
 	actualLast := link.Last()
@@ -89,11 +90,12 @@ func TestLastWithEmptySlice(t *testing.T) {
 
 func TestAllMatch(t *testing.T) {
 	inputSlice := []int{984, 8, 26}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
-	allMatchFunction := func(value int) bool {
-		return value % 2 == 0  //even means true
+	allMatchFunction := func(value interface{}) bool {
+		intValue := value.(int)
+		return intValue % 2 == 0  //even means true
 	}
 	match := link.AllMatch(allMatchFunction)
 
@@ -102,11 +104,12 @@ func TestAllMatch(t *testing.T) {
 
 func TestNotAllMatch(t *testing.T) {
 	inputSlice := []int{984, 7, 26}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
-	allMatchFunction := func(value int) bool {
-		return value % 2 == 0  //even means true
+	allMatchFunction := func(value interface{}) bool {
+		intValue := value.(int)
+		return intValue % 2 == 0  //even means true
 	}
 	match := link.AllMatch(allMatchFunction)
 
@@ -115,11 +118,12 @@ func TestNotAllMatch(t *testing.T) {
 
 func TestAllMatchWithEmptySlice(t *testing.T) {
 	var inputSlice []int
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
-	allMatchFunction := func(value int) bool {
-		return value % 2 == 0  //even means true
+	allMatchFunction := func(value interface{}) bool {
+		intValue := value.(int)
+		return intValue % 2 == 0  //even means true
 	}
 	match := link.AllMatch(allMatchFunction)
 
@@ -128,11 +132,12 @@ func TestAllMatchWithEmptySlice(t *testing.T) {
 
 func TestAnyMatch(t *testing.T) {
 	inputSlice := []int{985, 3, 26}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
-	anyMatchFunction := func(value int) bool {
-		return value % 2 == 0  //even means true
+	anyMatchFunction := func(value interface{}) bool {
+		intValue := value.(int)
+		return intValue % 2 == 0  //even means true
 	}
 	match := link.AnyMatch(anyMatchFunction)
 
@@ -141,11 +146,12 @@ func TestAnyMatch(t *testing.T) {
 
 func TestNotAnyMatch(t *testing.T) {
 	inputSlice := []int{985, 7, 29}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
-	anyMatchFunction := func(value int) bool {
-		return value % 2 == 0  //even means true
+	anyMatchFunction := func(value interface{}) bool {
+		intValue := value.(int)
+		return intValue % 2 == 0  //even means true
 	}
 	match := link.AnyMatch(anyMatchFunction)
 
@@ -154,11 +160,12 @@ func TestNotAnyMatch(t *testing.T) {
 
 func TestAnyMatchWithEmptySlice(t *testing.T) {
 	var inputSlice []int
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
-	anyMatchFunction := func(value int) bool {
-		return value % 2 == 0  //even means true
+	anyMatchFunction := func(value interface{}) bool {
+		intValue := value.(int)
+		return intValue % 2 == 0  //even means true
 	}
 	match := link.AnyMatch(anyMatchFunction)
 
@@ -167,11 +174,12 @@ func TestAnyMatchWithEmptySlice(t *testing.T) {
 
 func TestNoneMatch(t *testing.T) {
 	inputSlice := []int{985, 3, 27}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
-	noneMatchFunction := func(value int) bool {
-		return value % 2 == 0  //even means true
+	noneMatchFunction := func(value interface{}) bool {
+		intValue := value.(int)
+		return intValue % 2 == 0  //even means true
 	}
 	match := link.NoneMatch(noneMatchFunction)
 
@@ -180,11 +188,12 @@ func TestNoneMatch(t *testing.T) {
 
 func TestNotNoneMatch(t *testing.T) {
 	inputSlice := []int{985, 7, 28}
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
-	noneMatchFunction := func(value int) bool {
-		return value % 2 == 0  //even means true
+	noneMatchFunction := func(value interface{}) bool {
+		intValue := value.(int)
+		return intValue % 2 == 0  //even means true
 	}
 	match := link.NoneMatch(noneMatchFunction)
 
@@ -193,11 +202,12 @@ func TestNotNoneMatch(t *testing.T) {
 
 func TestNoneMatchWithEmptySlice(t *testing.T) {
 	var inputSlice []int
-	generation := generator.FromSlice(inputSlice)
+	generation := generator.FromSlice(helper.InterfaceSlice(inputSlice))
 	link := NewLink(generation)
 
-	noneMatchFunction := func(value int) bool {
-		return value % 2 == 0  //even means true
+	noneMatchFunction := func(value interface{}) bool {
+		intValue := value.(int)
+		return intValue % 2 == 0  //even means true
 	}
 	match := link.NoneMatch(noneMatchFunction)
 


### PR DESCRIPTION
Conver to use `interface{}` instead of exclusively `int`.  This allows for other types.