### PR TITLE
Rename the Package

### DIFF
--- a/begin.go
+++ b/begin.go
@@ -1,11 +1,11 @@
 package slice_chain
 
 import (
-	channelGeneratorImport "github.com/halprin/slice-chain/channelGenerator"
-	"github.com/halprin/slice-chain/channelIntermediate"
-	"github.com/halprin/slice-chain/generator"
-	"github.com/halprin/slice-chain/helper"
-	"github.com/halprin/slice-chain/intermediate"
+	channelGeneratorImport "github.com/halprin/rangechain/channelGenerator"
+	"github.com/halprin/rangechain/channelIntermediate"
+	"github.com/halprin/rangechain/generator"
+	"github.com/halprin/rangechain/helper"
+	"github.com/halprin/rangechain/intermediate"
 )
 
 func FromSlice(slice interface{}) *intermediate.Link {

--- a/begin_test.go
+++ b/begin_test.go
@@ -1,7 +1,7 @@
 package slice_chain
 
 import (
-	"github.com/halprin/slice-chain/generator"
+	"github.com/halprin/rangechain/generator"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/channelIntermediate/link.go
+++ b/channelIntermediate/link.go
@@ -1,7 +1,7 @@
 package channelIntermediate
 
 import (
-	"github.com/halprin/slice-chain/helper"
+	"github.com/halprin/rangechain/helper"
 )
 
 type Link struct {

--- a/channelIntermediate/link_chain_test.go
+++ b/channelIntermediate/link_chain_test.go
@@ -1,8 +1,8 @@
 package channelIntermediate
 
 import (
-	generator "github.com/halprin/slice-chain/channelGenerator"
-	"github.com/halprin/slice-chain/helper"
+	generator "github.com/halprin/rangechain/channelGenerator"
+	"github.com/halprin/rangechain/helper"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/channelIntermediate/link_termination_test.go
+++ b/channelIntermediate/link_termination_test.go
@@ -2,8 +2,8 @@ package channelIntermediate
 
 
 import (
-	generator "github.com/halprin/slice-chain/channelGenerator"
-	"github.com/halprin/slice-chain/helper"
+	generator "github.com/halprin/rangechain/channelGenerator"
+	"github.com/halprin/rangechain/helper"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -2,7 +2,7 @@ package generator
 
 import (
 	"errors"
-	"github.com/halprin/slice-chain/helper"
+	"github.com/halprin/rangechain/helper"
 	"reflect"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/halprin/slice-chain
+module github.com/halprin/rangechain
 
 go 1.16
 

--- a/intermediate/link_chain.go
+++ b/intermediate/link_chain.go
@@ -1,8 +1,8 @@
 package intermediate
 
 import (
-	"github.com/halprin/slice-chain/generator"
-	"github.com/halprin/slice-chain/helper"
+	"github.com/halprin/rangechain/generator"
+	"github.com/halprin/rangechain/helper"
 	"sort"
 )
 

--- a/intermediate/link_chain_parallel.go
+++ b/intermediate/link_chain_parallel.go
@@ -1,6 +1,6 @@
 package intermediate
 
-import "github.com/halprin/slice-chain/generator"
+import "github.com/halprin/rangechain/generator"
 
 func (receiver *Link) MapParallel(mapFunction func(interface{}) interface{}) *Link {
 	computedValues := false

--- a/intermediate/link_chain_parallel_test.go
+++ b/intermediate/link_chain_parallel_test.go
@@ -1,8 +1,8 @@
 package intermediate
 
 import (
-	"github.com/halprin/slice-chain/generator"
-	"github.com/halprin/slice-chain/helper"
+	"github.com/halprin/rangechain/generator"
+	"github.com/halprin/rangechain/helper"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/intermediate/link_chain_test.go
+++ b/intermediate/link_chain_test.go
@@ -1,8 +1,8 @@
 package intermediate
 
 import (
-	"github.com/halprin/slice-chain/generator"
-	"github.com/halprin/slice-chain/helper"
+	"github.com/halprin/rangechain/generator"
+	"github.com/halprin/rangechain/helper"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/intermediate/link_termination_test.go
+++ b/intermediate/link_termination_test.go
@@ -2,8 +2,8 @@ package intermediate
 
 
 import (
-	"github.com/halprin/slice-chain/generator"
-	"github.com/halprin/slice-chain/helper"
+	"github.com/halprin/rangechain/generator"
+	"github.com/halprin/rangechain/helper"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )


### PR DESCRIPTION
Closes #11.

Renames this package to `rangechain` from `slice-chain`.