### PR TITLE
Add Go Doc Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # rangechain
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/halprin/rangechain.svg)](https://pkg.go.dev/github.com/halprin/rangechain)
+
 Chain together lazily computed modifications to range-able containers.
 E.g. slices, arrays, maps, and channels.
 


### PR DESCRIPTION
Added the Go documentation badge and link to https://pkg.go.dev/github.com/halprin/rangechain.