### PR TITLE
Add Iterators Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ container := []int{987, 3, 26}
 chain := rangechain.FromSlice(container)
 ```
 
-| Function | Arguments | Description |
-| --- | --- | --- |
-| `FromSlice` | • `slice` - A slice to be used to start the chain. | Starts the chain with the supplied slice.  Chaining and terminating methods can now be called on the result. |
-| `FromArray` | • `array` - An array to be used to start the chain. | Starts the chain with the supplied array.  Chaining and terminating methods can now be called on the result. |
-| `FromChannel` | • `channel` - A channel to be used to start the chain. | Starts the chain with the supplied channel.  Chaining and terminating methods can now be called on the result. |
-| `FromMap` | • `aMap` - A map to be used to start the chain. | Starts the chain with the supplied map.  Chaining and terminating methods can now be called on the result.  The singular value used to represent the key and value pairs is `keyvalue.KeyValuer` of `github.com/halprin/rangechain/keyvalue`. |
+| Function       | Arguments                                                        | Description                                                                                                                                                                                                                                   |
+|----------------|------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `FromSlice`    | • `slice` - A slice to be used to start the chain.               | Starts the chain with the supplied slice.  Chaining and terminating methods can now be called on the result.                                                                                                                                  |
+| `FromArray`    | • `array` - An array to be used to start the chain.              | Starts the chain with the supplied array.  Chaining and terminating methods can now be called on the result.                                                                                                                                  |
+| `FromChannel`  | • `channel` - A channel to be used to start the chain.           | Starts the chain with the supplied channel.  Chaining and terminating methods can now be called on the result.                                                                                                                                |
+| `FromMap`      | • `aMap` - A map to be used to start the chain.                  | Starts the chain with the supplied map.  Chaining and terminating methods can now be called on the result.  The singular value used to represent the key and value pairs is `keyvalue.KeyValuer` of `github.com/halprin/rangechain/keyvalue`. |
+| `FromIterator` | • `anIterator` - An `iter.Seq[T]` to be used to start the chain. | Starts the chain with the supplied iterator.  Chaining and terminating methods can now be called on the result.                                                                                                                               |
 
 From there, one can call a plethora of additional methods to modify the container passed in originally.  The methods are
 outlined below.  The methods fall into one of two categories: chaining or terminating.

--- a/begin.go
+++ b/begin.go
@@ -2,6 +2,7 @@ package rangechain
 
 import (
 	"github.com/halprin/rangechain/internal/generator"
+	"iter"
 )
 
 // FromSlice starts the chain with the supplied slice.
@@ -37,5 +38,14 @@ func FromMap(aMap interface{}) *Link {
 	mapGenerator := generator.FromMap(aMap)
 
 	link := newLink(mapGenerator)
+	return link
+}
+
+// FromIterator starts the chain with the supplied iterator.
+// Chaining and terminating methods can now be called on the result.
+func FromIterator[T any](anIterator iter.Seq[T]) *Link {
+	iterGenerator := generator.FromIterator(anIterator)
+
+	link := newLink(iterGenerator)
 	return link
 }

--- a/begin_test.go
+++ b/begin_test.go
@@ -3,6 +3,7 @@ package rangechain
 import (
 	"github.com/halprin/rangechain/keyvalue"
 	"github.com/stretchr/testify/assert"
+	"slices"
 	"testing"
 )
 
@@ -78,6 +79,19 @@ func TestFromMap(t *testing.T) {
 	slice, err := chain.Slice()
 	//not testing the order because we are not guaranteed the order in which a map is iterated over
 	assertEqualsBasedOnKeyValuerInterface(t, expectedOutput, slice)
+	assert.Nil(err)
+}
+
+func TestFromIterator(t *testing.T) {
+	assert := assert.New(t)
+
+	inputSlice := []string{"DogCows", "goes", "Moof!", "Do", "you", "like", "Clarus", "the", "DogCow?"}
+	inputIterator := slices.Values(inputSlice)
+	expectedOutput := []interface{}{"DogCows", "goes", "Moof!", "Do", "you", "like", "Clarus", "the", "DogCow?"}
+	chain := FromIterator(inputIterator)
+
+	slice, err := chain.Slice()
+	assert.Equal(expectedOutput, slice)
 	assert.Nil(err)
 }
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -4,6 +4,7 @@ package generator
 import (
 	"errors"
 	"github.com/halprin/rangechain/internal/helper"
+	"iter"
 	"reflect"
 )
 
@@ -69,6 +70,26 @@ func FromMap(aMap interface{}) func() (interface{}, error) {
 		}
 
 		return tuple, nil
+	}
+}
+
+func FromIterator[T any](anIterator iter.Seq[T]) func() (interface{}, error) {
+	//if !helper.IsIterator(anIterator) {
+	//	panic("non-iterator type provided")
+	//}
+	//
+	//sequence := anIterator.(iter.Seq[any])
+
+	next, stop := iter.Pull(anIterator)
+
+	return func() (interface{}, error) {
+		value, ok := next()
+		if !ok {
+			stop()
+			return 0, Exhausted
+		}
+
+		return value, nil
 	}
 }
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -74,12 +74,6 @@ func FromMap(aMap interface{}) func() (interface{}, error) {
 }
 
 func FromIterator[T any](anIterator iter.Seq[T]) func() (interface{}, error) {
-	//if !helper.IsIterator(anIterator) {
-	//	panic("non-iterator type provided")
-	//}
-	//
-	//sequence := anIterator.(iter.Seq[any])
-
 	next, stop := iter.Pull(anIterator)
 
 	return func() (interface{}, error) {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"github.com/stretchr/testify/assert"
+	"slices"
 	"testing"
 )
 
@@ -120,7 +121,7 @@ func TestMapNotPanicsGivenMap(t *testing.T) {
 	assert.NotPanics(t, func() {
 		FromMap(map[string]int{
 			"DogCow": 1,
-			"Moof": 1976,
+			"Moof":   1976,
 		})
 	})
 }
@@ -143,6 +144,28 @@ func TestMapEndsWithError(t *testing.T) {
 
 	_, err = generator()
 	assert.ErrorIs(err, Exhausted)
+}
+
+func TestFromIteratorWithLastTimeError(t *testing.T) {
+	assert := assert.New(t)
+
+	generator := FromIterator(slices.Values([]interface{}{9}))
+
+	_, err := generator()
+
+	assert.NoError(err)
+
+	_, err = generator()
+
+	assert.ErrorIs(err, Exhausted)
+}
+
+func TestFromIteratorEmpty(t *testing.T) {
+	generator := FromIterator(slices.Values([]interface{}{}))
+
+	_, err := generator()
+
+	assert.ErrorIs(t, err, Exhausted)
 }
 
 func createTestChannel(size int) chan interface{} {

--- a/internal/helper/type.go
+++ b/internal/helper/type.go
@@ -1,7 +1,6 @@
 package helper
 
 import (
-	"iter"
 	"reflect"
 )
 
@@ -23,10 +22,4 @@ func IsChannel(value interface{}) bool {
 func IsMap(value interface{}) bool {
 	concreteValue := reflect.ValueOf(value)
 	return concreteValue.Kind() == reflect.Map
-}
-
-func IsIterator(value interface{}) bool {
-	_, ok := value.(iter.Seq[any])
-
-	return ok
 }

--- a/internal/helper/type.go
+++ b/internal/helper/type.go
@@ -1,6 +1,9 @@
 package helper
 
-import "reflect"
+import (
+	"iter"
+	"reflect"
+)
 
 func IsSlice(value interface{}) bool {
 	concreteValue := reflect.ValueOf(value)
@@ -20,4 +23,10 @@ func IsChannel(value interface{}) bool {
 func IsMap(value interface{}) bool {
 	concreteValue := reflect.ValueOf(value)
 	return concreteValue.Kind() == reflect.Map
+}
+
+func IsIterator(value interface{}) bool {
+	_, ok := value.(iter.Seq[any])
+
+	return ok
 }


### PR DESCRIPTION
Add support for `iter.Seq[T]` that was released in Go 1.23.